### PR TITLE
Add catch for empty nullspace in suppress_secondary

### DIFF
--- a/R/cell_suppression.R
+++ b/R/cell_suppression.R
@@ -72,6 +72,8 @@ suppress_secondary <- function(
     ...,
     solver = 'highs',
     max_iter = 100L) {
+  if (nrow(nullspace) == 0) return(suppress)
+
   if (!ROI::ROI_require_solver(solver, warn = -1L)) {
     cli::cli_abort(c(
       "Requested {.pkg ROI} solver {.val {solver}} but it is not available.",

--- a/tests/testthat/test-cell_suppression.R
+++ b/tests/testthat/test-cell_suppression.R
@@ -51,6 +51,16 @@ test_that("determine_cell_suppression correctly suppresses cells", {
   testthat::expect_equal(soln, test$suppress, check.attributes = FALSE)
 })
 
+test_that("suppress_secondary deals with an empty nullspace (#9)", {
+  data <- seq(0, 10, by = 2)
+  suppress <- c(FALSE, TRUE, TRUE, FALSE, FALSE, FALSE)
+  nullspace <- matrix(NA_real_, nrow = 0, ncol = 6)
+  expect_equal(
+    suppress_secondary(data, suppress, nullspace),
+    suppress
+  )
+})
+
 test_that("suppress_secondary aborts if bounds are too tight", {
   skip_if_not_installed('ROI.plugin.highs')
 


### PR DESCRIPTION
Closes #9.

I opted to not include a test as it seems excessive and something that is unlikely to regress, but if desired, this one works:

```
test_that("suppress_secondary deals with an empty nullspace", {
  suppress = c(F, T, T, F, F, F)
  expect_equal(suppress_secondary(seq(0, 10, 2), suppress, 
                                  nullspace = matrix(ncol = 6, nrow = 0)),
               suppress)
})
```

Tests passed except for warning that has been dealt with in #8 